### PR TITLE
refactor(mobile): rename brand identifier iyque to yjaiscrm

### DIFF
--- a/frontEnd/mobile/src/api/category.ts
+++ b/frontEnd/mobile/src/api/category.ts
@@ -5,7 +5,7 @@ const service = '/category'
 
 /** 列表
  */
-export const getList = (mediaType) => get(`${service}/findIYqueCategory`, { mediaType })
+export const getList = (mediaType) => get(`${service}/findYjaiscrmCategory`, { mediaType })
 
 /** 详情
  * @param {*} params

--- a/frontEnd/mobile/src/api/common.ts
+++ b/frontEnd/mobile/src/api/common.ts
@@ -17,7 +17,7 @@ export function getCosConfig(data) {
     url: '/file/get/config',
     params: data,
   }).then(({ data }) => {
-    let res = {}
+    const res = {}
     Object.keys(data).forEach((key) => {
       res[key] = decryptAES(data[key])
     })
@@ -28,7 +28,7 @@ export function getCosConfig(data) {
 // 获取临时素材media_id
 export function getMaterialMediaId(params) {
   return request({
-    url: '/iYqueSys/uploadMediaId',
+    url: '/yjaiscrmSys/uploadMediaId',
     params,
   })
 }
@@ -39,7 +39,7 @@ export function getMaterialMediaId(params) {
  */
 export function getAgentTicket(url) {
   return request({
-    url: '/iYqueSys/getAgentTicket',
+    url: '/yjaiscrmSys/getAgentTicket',
     params: {
       url,
     },
@@ -75,7 +75,7 @@ export function getWxTicket(data) {
  */
 export function login(authCode) {
   return request({
-    url: '/iYqueSys/weComLogin',
+    url: '/yjaiscrmSys/weComLogin',
     method: 'get',
     params: {
       authCode,
@@ -88,7 +88,7 @@ export function login(authCode) {
  */
 export function getUserInfo() {
   return request({
-    url: '/iYqueSys/getBaseInfo',
+    url: '/yjaiscrmSys/getBaseInfo',
   })
 }
 
@@ -114,7 +114,7 @@ export function getWxRedirect(redirectUrl = location.href) {
  */
 export function getWcRedirect(redirectUrl = location.href) {
   return request({
-    url: '/iYqueSys/weComRedirect',
+    url: '/yjaiscrmSys/weComRedirect',
     method: 'get',
     params: {
       redirectUrl,

--- a/frontEnd/mobile/src/utils/request.js
+++ b/frontEnd/mobile/src/utils/request.js
@@ -54,7 +54,7 @@ function requestFactory(getway = '') {
       // }
       else {
         closeToast()
-        if (process.env.NODE_ENV === 'development' || location.href.includes('show.iyque.cn')) {
+        if (process.env.NODE_ENV === 'development' || location.href.includes('show.yjaiscrm.cn')) {
           showDialog({
             title: '接口提示',
             message: `${res.config.url}, ${data.code} @_@: ${data.msg}`,

--- a/frontEnd/mobile/src/views/customerComplaint/api.js
+++ b/frontEnd/mobile/src/views/customerComplaint/api.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, del: _del } = request
-const serve = '/iYqueComplaint'
+const serve = '/yjaiscrmComplaint'
 
 /**
  * 列表
@@ -15,7 +15,7 @@ export function getList(data) {
   return get(`${serve}/findComplaintByPage`, data)
 }
 
-export const getDetail = (id) => get(`${serve}/findIYQueComplainById/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmComplainById/${id}`)
 
 /**
  * 处理投诉意见

--- a/frontEnd/mobile/sys.config.js
+++ b/frontEnd/mobile/sys.config.js
@@ -8,9 +8,9 @@ const envs = {
     BASE_API: 'http://127.0.0.1:8085', // 接口基础路径
   },
   production: {
-    DOMAIN: 'https://iyque.cn',
+    DOMAIN: 'https://yjaiscrm.cn',
     BASE_URL: '/openmobile/',
-    BASE_API: 'https://iyque.cn/iyque',
+    BASE_API: 'https://yjaiscrm.cn/yjaiscrm',
   },
 }
 
@@ -26,6 +26,6 @@ const env = envs[mode] || {}
 // 配置项
 export const config = {
   ...env,
-  SYSTEM_NAME: '源雀', // 系统简称
+  SYSTEM_NAME: 'yjaiscrm', // 系统简称
 }
 Object.assign(config, { BASE_URL, RUN_ENV: mode })


### PR DESCRIPTION
## Summary
- Unit 3 of the monorepo brand rename: `iyque` → `yjaiscrm` across the mobile H5 app (`frontEnd/mobile/**`).
- Replaces all five occurrences (only) of the old brand in mobile sources: API URL prefixes (`/iYqueSys/*`, `/iYqueComplaint`, `findIYque*`/`findIYQue*` path segments), the `show.iyque.cn` dev guard in `request.js`, the production `DOMAIN`/`BASE_API` in `sys.config.js`, and the user-visible `SYSTEM_NAME` (browser title via `VITE_APP_TITLE`) which becomes `'yjaiscrm'`.
- Casing follows the team's deterministic rule (capital-leading match → `Yjaiscrm`, lowercase-leading → `yjaiscrm`), so URLs stay aligned with the parallel backend rename (`/iYqueSys` → `/yjaiscrmSys`) and nginx (`/iyque/` → `/yjaiscrm/`).

Files changed (5):
- `frontEnd/mobile/sys.config.js`
- `frontEnd/mobile/src/utils/request.js`
- `frontEnd/mobile/src/api/category.ts`
- `frontEnd/mobile/src/api/common.ts`
- `frontEnd/mobile/src/views/customerComplaint/api.js`

## Test plan
- [x] `grep -ri "iyque" frontEnd/mobile --exclude-dir=node_modules --exclude-dir=dist` returns 0 lines.
- [x] `grep -ri "源雀" frontEnd/mobile --exclude-dir=node_modules --exclude-dir=dist` returns 0 lines.
- [x] `cd frontEnd/mobile && npm install && npm run build` succeeds (built in ~1.2s).
- [x] `npm run lint` only emits pre-existing repo errors (unused-vars, missing `lang` attrs, multi-word component names) — none introduced by this rename.
- [ ] Cross-unit verification once the parallel backend (`/iYqueSys` → `/yjaiscrmSys`) and nginx (`/iyque/` → `/yjaiscrm/`) PRs land — front and back URLs must stay aligned per the agreed casing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)