### PR TITLE
refactor(pc): rename brand identifier iyque to yjaiscrm (Unit 2)

### DIFF
--- a/frontEnd/pc/README.md
+++ b/frontEnd/pc/README.md
@@ -38,14 +38,14 @@
 // 环境变量
 const envs = {
   development: {
-    DOMAIN: 'https://show.iyque.cn', // 站点域名，会根据此处域名判断应用环境
+    DOMAIN: 'https://show.yjaiscrm.cn', // 站点域名，会根据此处域名判断应用环境
     BASE_URL: '/tools/', // 页面路由基础路径 /*/*/，eg：/a/
-    BASE_API: 'https://show.iyque.cn/iyque', // 接口基础路径
+    BASE_API: 'https://show.yjaiscrm.cn/yjaiscrm', // 接口基础路径
   },
   production: {
-    DOMAIN: 'https://show.iyque.cn',
+    DOMAIN: 'https://show.yjaiscrm.cn',
     BASE_URL: '/tools/',
-    BASE_API: 'https://show.iyque.cn/iyque',
+    BASE_API: 'https://show.yjaiscrm.cn/yjaiscrm',
   },
 }
 
@@ -58,10 +58,10 @@ export const env = { ...envs[mode], ENV: mode }
 
 // 系统常量配置
 export const common = {
-  SYSTEM_NAME: '源雀', // 系统简称
+  SYSTEM_NAME: 'yjaiscrm', // 系统简称
   SYSTEM_SLOGAN:
-    '<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">源雀SCRM -基于SpringCloud+Vue架构,100%开放源码的企微私域营销系统</a> ', // 系统标语
-  COPYRIGHT: 'Copyright © 2024 源雀 All Rights Reserved.', // 版权信息
+    '<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">yjaiscrm SCRM -基于SpringCloud+Vue架构,100%开放源码的企微私域营销系统</a> ', // 系统标语
+  COPYRIGHT: 'Copyright © 2024 yjaiscrm All Rights Reserved.', // 版权信息
   LOGO: env.BASE_URL + 'static/logo.png', // 深色logo
   COOKIEEXPIRES: 0.5, // token在Cookie中存储的天数，默认0.5天
 }

--- a/frontEnd/pc/index.html
+++ b/frontEnd/pc/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" href="/static/logo.png">
-  <title>源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn</title>
+  <title>yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn</title>
   <style>
     #loader-wrapper {
       position: absolute;

--- a/frontEnd/pc/src/api/ai.js
+++ b/frontEnd/pc/src/api/ai.js
@@ -2,7 +2,7 @@ import request from '@/utils/request'
 
 export function chatWithMemory(data) {
   return request({
-    url: '/iYqueAi/chatWithMemory',
+    url: '/yjaiscrmAi/chatWithMemory',
     method: 'post',
     data
   })
@@ -10,20 +10,20 @@ export function chatWithMemory(data) {
 
 export function getAvailableModels() {
   return request({
-    url: '/iYqueAi/models',
+    url: '/yjaiscrmAi/models',
     method: 'get'
   })
 }
 
 export function getFunctionRoutes() {
   return request({
-    url: '/iYqueAi/functionRoutes',
+    url: '/yjaiscrmAi/functionRoutes',
     method: 'get'
   })
 }
 
 export function chatWithMemoryStream(data, onMessage, onError, onComplete) {
-  const url = '/api/iYqueAi/chatWithMemoryStream'
+  const url = '/api/yjaiscrmAi/chatWithMemoryStream'
   
   return new Promise((resolve, reject) => {
     let fullResponse = ''
@@ -166,7 +166,7 @@ export function chatWithMemoryStream(data, onMessage, onError, onComplete) {
 }
 
 export function navigationChatStream(data, onMessage, onError, onComplete) {
-  const url = '/api/iYqueAi/navigationChatStream'
+  const url = '/api/yjaiscrmAi/navigationChatStream'
   
   return new Promise((resolve, reject) => {
     let fullResponse = ''

--- a/frontEnd/pc/src/api/category.ts
+++ b/frontEnd/pc/src/api/category.ts
@@ -5,7 +5,7 @@ const service = '/category'
 
 /** 列表
  */
-export const getList = (mediaType) => get(`${service}/findIYqueCategory`, { mediaType })
+export const getList = (mediaType) => get(`${service}/findYjaiscrmCategory`, { mediaType })
 
 /** 详情
  * @param {*} params

--- a/frontEnd/pc/src/api/common.js
+++ b/frontEnd/pc/src/api/common.js
@@ -4,7 +4,7 @@ const { get, post, put, delt } = request
 export const upload = (data) => post(`/file/upload`, data)
 
 export const getUserList = (data) =>
-	get(`/iYqueUser/findIYqueUser`, data).then((res) => {
+	get(`/yjaiscrmUser/findYjaiscrmUser`, data).then((res) => {
 		if (res.code == 200) {
 			res.data?.forEach((element) => {
 				element.id = element.userId
@@ -13,10 +13,10 @@ export const getUserList = (data) =>
 		return res
 	})
 
-export const getTagList = (data) => get(`/iYqueTag/findIYqueTag`, data)
+export const getTagList = (data) => get(`/yjaiscrmTag/findYjaiscrmTag`, data)
 
 export function getRemarkList() {
 	return request({
-		url: '/iYqueCommon/findRemarksType',
+		url: '/yjaiscrmCommon/findRemarksType',
 	})
 }

--- a/frontEnd/pc/src/components/AiChat.vue
+++ b/frontEnd/pc/src/components/AiChat.vue
@@ -30,7 +30,7 @@
       </div>
       <div class="ai-chat-sidebar" :class="{ 'sidebar-open': showSidebar }">
         <div class="sidebar-header">
-          <h4>源雀SCRM</h4>
+          <h4>yjaiscrm SCRM</h4>
           <button class="new-chat-button sidebar-new-chat" @click="createNewChat">+ 新会话</button>
         </div>
         <div class="sidebar-body">
@@ -248,7 +248,7 @@ const tempInput = ref('')
 const watermarks = ref([])
 
 const generateWatermarks = () => {
-  const watermarkTexts = ['源雀SCRM']
+  const watermarkTexts = ['yjaiscrm SCRM']
   const count = 8
   const newWatermarks = []
   const usedPositions = []

--- a/frontEnd/pc/src/components/WelcomeForm.vue
+++ b/frontEnd/pc/src/components/WelcomeForm.vue
@@ -15,7 +15,7 @@ export default {
 				beginTime: '',
 				endTime: '',
 				workCycle: [],
-				weclomeMsg: '欢迎使用源雀scrm👉http://iyque.cn',
+				weclomeMsg: '欢迎使用yjaiscrm scrm👉http://yjaiscrm.cn',
 			},
 			rules: {
 				weclomeMsg: [{ required: true, message: '必填项', trigger: 'blur' }],

--- a/frontEnd/pc/src/layout/components/Sidebar/index.vue
+++ b/frontEnd/pc/src/layout/components/Sidebar/index.vue
@@ -26,7 +26,7 @@
             :base-path="resolvePath(route.path, item)" />
         </div>
       </el-scrollbar>
-      <a href="https://iyque.cn/">
+      <a href="https://yjaiscrm.cn/">
         <el-image style="width: 100%" :src="image" fit="fill"></el-image>
       </a>
     </el-menu>

--- a/frontEnd/pc/src/views/chat/api.js
+++ b/frontEnd/pc/src/views/chat/api.js
@@ -27,7 +27,7 @@ export const findAiAnalysisMsgAudits = (data) => get(`${serve}/findAiAnalysisMsg
  * @param {*} data 
  * @returns 
  */
-export const findIYqueMsgRules = (data) => get(`${serve}/findIYqueMsgRules`, data)
+export const findYjaiscrmMsgRules = (data) => get(`${serve}/findYjaiscrmMsgRules`, data)
 
 
 

--- a/frontEnd/pc/src/views/chat/apiLink.js
+++ b/frontEnd/pc/src/views/chat/apiLink.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue/shortLink'
+const serve = '/yjaiscrm/shortLink'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue/shortLink'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueShortLink`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmShortLink`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -46,11 +46,11 @@ export function update(data) {
 	return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 

--- a/frontEnd/pc/src/views/chat/index.vue
+++ b/frontEnd/pc/src/views/chat/index.vue
@@ -5,12 +5,12 @@ import { env } from '../../../sys.config'
 import aev from './aev.vue'
 import synch from './synch.vue'
 
-let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
+let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
+		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
 
 		return {
 			activeName: 'first',
@@ -73,7 +73,7 @@ export default {
 		this.getList()
 		this.getData()
 		this.findAiAnalysisMsgAudits()
-		this.findIYqueMsgRules()
+		this.findYjaiscrmMsgRules()
 	},
 	mounted() {},
 	methods: {
@@ -106,7 +106,7 @@ export default {
 					this.$store.loading = true
 					return del(ids).then((res) => {
 						this.msgSuccess('删除成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -134,7 +134,7 @@ export default {
 				.finally(() => (this.$store.loading = false))
 		},
 
-		findIYqueMsgRules(page) {
+		findYjaiscrmMsgRules(page) {
 			if(page == null){
 				page=this.aiRuleParm;
 			}
@@ -142,7 +142,7 @@ export default {
 			this.$store.loading = true
 		    console.log(page);
 			
-			findIYqueMsgRules(page)
+			findYjaiscrmMsgRules(page)
 				.then(({ data, count }) => {
 					this.aiRuleList = data
 					this.aiRuleTotal = +count
@@ -159,7 +159,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -236,7 +236,7 @@ export default {
 			}
 
 	
-			 this.findIYqueMsgRules(queryParm)
+			 this.findYjaiscrmMsgRules(queryParm)
 		},
 
 		restting() {
@@ -296,7 +296,7 @@ export default {
 						this.multipleSelection?.join?.(',')
 					).then((res) => {
 						this.msgSuccess('操作成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -309,9 +309,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>

--- a/frontEnd/pc/src/views/complaintManage/api.ts
+++ b/frontEnd/pc/src/views/complaintManage/api.ts
@@ -1,7 +1,7 @@
 import request from '@/utils/request'
 const { get, post, put, delt: _del } = request
 
-const service = '/iYqueComplaint'
+const service = '/yjaiscrmComplaint'
 
 /** 列表
  * @param {*} params
@@ -23,15 +23,15 @@ export const distributeHandle = (id) => get(`${service}/distributeHandle/${id}`)
     }
 ]
  */
-export const setIYQueComplaintTip = (data) => {
-  return post(`${service}/setIYQueComplaintTip`, data)
+export const setYjaiscrmComplaintTip = (data) => {
+  return post(`${service}/setYjaiscrmComplaintTip`, data)
 }
 
 /**
  * 获取投诉通知人
  * @returns
  */
-export const findIYQueComplaintTips = () => get(`${service}/findIYQueComplaintTips`)
+export const findYjaiscrmComplaintTips = () => get(`${service}/findYjaiscrmComplaintTips`)
 
 /** 删除
  * @param {*} ids

--- a/frontEnd/pc/src/views/complaintManage/list.vue
+++ b/frontEnd/pc/src/views/complaintManage/list.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { getList, setIYQueComplaintTip, distributeHandle, updateStatus, findIYQueComplaintTips } from './api'
+import { getList, setYjaiscrmComplaintTip, distributeHandle, updateStatus, findYjaiscrmComplaintTips } from './api'
 const handleState = { '1': '未处理', '2': '已处理' }
 
 const employees = ref([])
@@ -14,7 +14,7 @@ const selectedEmployeeName = computed(() => {
 })
 onMounted(async () => {
   try {
-    const response = await findIYQueComplaintTips()
+    const response = await findYjaiscrmComplaintTips()
     if (response.data && Array.isArray(response.data)) {
       const userNames = response.data
         .filter((item) => item && typeof item.userName === 'string')
@@ -52,7 +52,7 @@ onMounted(async () => {
           :formProps="{ 'label-width': 'auto' }"
           :rules="{ users: { required: true, message: '必选项', trigger: 'change' } }"
           @confirm="
-            () => $refs.dialogRef.confirm(() => setIYQueComplaintTip(form.users?.map((e) => ({ userId: e.userId }))))
+            () => $refs.dialogRef.confirm(() => setYjaiscrmComplaintTip(form.users?.map((e) => ({ userId: e.userId }))))
           ">
           <template #form="{}">
             <el-form-item prop="users" class="w100" label="投诉处理人">

--- a/frontEnd/pc/src/views/config/api.js
+++ b/frontEnd/pc/src/views/config/api.js
@@ -1,12 +1,12 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iYqueConfig'
+const serve = '/yjaiscrmConfig'
 
-export const getDetail = (id) => get(`${serve}/findIYqueConfig`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmConfig`)
 
 export const addOrUpdate = (data) => post(`${serve}/saveOrUpdate`, data)
 
-const serveWel = '/iYqueDefaultMsg'
+const serveWel = '/yjaiscrmDefaultMsg'
 export const getDetailWel = (id) => get(`${serveWel}/findDefaultMsg`)
 
 /**

--- a/frontEnd/pc/src/views/customer/api.ts
+++ b/frontEnd/pc/src/views/customer/api.ts
@@ -5,7 +5,7 @@ import request from '@/utils/request'
 const { get, post, put, delt: _del } = request
 
 const service = '/customerInfo'
-const tagService = '/iYqueTag'
+const tagService = '/yjaiscrmTag'
 
 // 定义API响应类型
 interface ApiResponse<T = any> {
@@ -49,7 +49,7 @@ export const synchCustomer = (data?: any): Promise<ApiResponse> => post(`${servi
 /** 获取客户标签列表
  * @returns
  */
-export const getCustomerTags = (data?: any): Promise<ApiResponse<CustomerTag[]>> => get(`${tagService}/findIYqueTag`, data)
+export const getCustomerTags = (data?: any): Promise<ApiResponse<CustomerTag[]>> => get(`${tagService}/findYjaiscrmTag`, data)
 
 /** 为客户打标签
  * @param {*} params

--- a/frontEnd/pc/src/views/customerTag/api.js
+++ b/frontEnd/pc/src/views/customerTag/api.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iYqueTag'
+const serve = '/yjaiscrmTag'
 
 /**
  * 列表
@@ -8,7 +8,7 @@ const serve = '/iYqueTag'
  */
 export const getList = (data) => {
   // 添加标签分组类型(1:客户企业标签;2:客群标签)
-  return get(`${serve}/findIYqueTagGroups`, { ...data, groupTagType: 1 })
+  return get(`${serve}/findYjaiscrmTagGroups`, { ...data, groupTagType: 1 })
 }
 // 详情
 export const getDetail = (id) => get(`${serve}/getKeyWordGroupBaseInfo/${id}`)

--- a/frontEnd/pc/src/views/fileSecurity/index.vue
+++ b/frontEnd/pc/src/views/fileSecurity/index.vue
@@ -56,7 +56,7 @@ export default {
 		this.getList()
 		// this.getData()
 		// this.findAiAnalysisMsgAudits()
-		// this.findIYqueMsgRules()
+		// this.findYjaiscrmMsgRules()
 	},
 	mounted() {},
 	methods: {
@@ -112,7 +112,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -166,9 +166,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>

--- a/frontEnd/pc/src/views/friendCircle/api.ts
+++ b/frontEnd/pc/src/views/friendCircle/api.ts
@@ -3,7 +3,7 @@ import request from '@/utils/request'
 // 朋友圈列表
 export function getFriendCircleList(params: any) {
   return request({
-    url: '/iYqueSys/friendCircle/list',
+    url: '/yjaiscrmSys/friendCircle/list',
     method: 'get',
     params
   })
@@ -12,7 +12,7 @@ export function getFriendCircleList(params: any) {
 // 新增朋友圈
 export function createFriendCircle(data: any) {
   return request({
-    url: '/iYqueSys/friendCircle/create',
+    url: '/yjaiscrmSys/friendCircle/create',
     method: 'post',
     data
   })
@@ -21,7 +21,7 @@ export function createFriendCircle(data: any) {
 // 获取朋友圈详情
 export function getFriendCircleDetail(id: string) {
   return request({
-    url: `/iYqueSys/friendCircle/detail/${id}`,
+    url: `/yjaiscrmSys/friendCircle/detail/${id}`,
     method: 'get'
   })
 }
@@ -29,7 +29,7 @@ export function getFriendCircleDetail(id: string) {
 // 删除朋友圈
 export function deleteFriendCircle(id: string) {
   return request({
-    url: `/iYqueSys/friendCircle/${id}`,
+    url: `/yjaiscrmSys/friendCircle/${id}`,
     method: 'delete'
   })
 }
@@ -37,7 +37,7 @@ export function deleteFriendCircle(id: string) {
 // 更新朋友圈
 export function updateFriendCircle(data: any) {
   return request({
-    url: '/iYqueSys/friendCircle/update',
+    url: '/yjaiscrmSys/friendCircle/update',
     method: 'put',
     data
   })
@@ -46,7 +46,7 @@ export function updateFriendCircle(data: any) {
 // AI生成朋友圈内容
 export function aiGenerateFriendCircle(prompt: string, modelName?: string) {
   return request({
-    url: '/iYqueSys/friendCircle/ai/generate',
+    url: '/yjaiscrmSys/friendCircle/ai/generate',
     method: 'get',
     params: { prompt, modelName }
   })

--- a/frontEnd/pc/src/views/groupChat/api.js
+++ b/frontEnd/pc/src/views/groupChat/api.js
@@ -1,7 +1,7 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iYqueChat'
-const tagService = '/iYqueTag'
+const serve = '/yjaiscrmChat'
+const tagService = '/yjaiscrmTag'
 
 /**
  * 列表
@@ -12,7 +12,7 @@ const tagService = '/iYqueTag'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueChatPage`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmChatPage`, data)
 
 
 
@@ -20,13 +20,13 @@ export const getList = (data) => get(`${serve}/findIYqueChatPage`, data)
  * 客群同步
  * @returns 
  */
-export const synchIyqueChat = () => post(`${serve}/synchIyqueChat`)
+export const synchYjaiscrmChat = () => post(`${serve}/synchYjaiscrmChat`)
 
 /**
  * 获取客群标签列表
  * @returns
  */
-export const getGroupTags = (data) => get(`${tagService}/findIYqueTag`, { ...data, groupTagType: 2 })
+export const getGroupTags = (data) => get(`${tagService}/findYjaiscrmTag`, { ...data, groupTagType: 2 })
 
 /**
  * 为客群打标签

--- a/frontEnd/pc/src/views/groupChat/index.vue
+++ b/frontEnd/pc/src/views/groupChat/index.vue
@@ -2,12 +2,12 @@
 import * as api from './api'
 import { env } from '../../../sys.config'
 import TagEllipsis from '@/components/TagEllipsis'
-let { getList,synchIyqueChat, getGroupTags, tagGroups} = {}
+let { getList,synchYjaiscrmChat, getGroupTags, tagGroups} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,synchIyqueChat, getGroupTags, tagGroups} = api)
+		let _ = ({ getList,synchYjaiscrmChat, getGroupTags, tagGroups} = api)
 
 		return {
 			activeName: 'first',
@@ -73,8 +73,8 @@ export default {
 
 
 
-		synchIyqueChat() {
-            synchIyqueChat()
+		synchYjaiscrmChat() {
+            synchYjaiscrmChat()
 			 .then(response => {
 			
 				this.msgSuccess(response.msg)
@@ -188,9 +188,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>
@@ -210,7 +210,7 @@ export default {
 				</el-form>
 					
 					<div class="fxbw">
-						<el-button type="primary" @click="synchIyqueChat()">同步客群</el-button>
+						<el-button type="primary" @click="synchYjaiscrmChat()">同步客群</el-button>
 					</div>
 					<el-table
 					:data="list"

--- a/frontEnd/pc/src/views/groupCode/aev.vue
+++ b/frontEnd/pc/src/views/groupCode/aev.vue
@@ -172,12 +172,12 @@ export default {
 
 		/** 获取详情 */
 		getDetail(id) {
-			// findIYqueMsgAnnexByMsgId(id).then((res) => {
+			// findYjaiscrmMsgAnnexByMsgId(id).then((res) => {
 			// 	console.log(res.data)
 			// 	this.form.annexLists = res.data
 			// })
 			// this.form.startPeriodAnnex &&
-			// 	findIYqueMsgPeriodAnnexByMsgId(id).then((res) => {
+			// 	findYjaiscrmMsgPeriodAnnexByMsgId(id).then((res) => {
 			// 		console.log(res.data)
 			// 		this.form.periodAnnexLists = res.data
 			// 	})

--- a/frontEnd/pc/src/views/groupCode/api.js
+++ b/frontEnd/pc/src/views/groupCode/api.js
@@ -11,10 +11,10 @@ const serve = '/iychatCode'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueChatCode`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmChatCode`, data)
 
 // 详情
-// export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+// export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -45,4 +45,4 @@ export function update(data) {
 }
 
 //获取企业微信群
-export const getGroupList = () => get(`${serve}/findIYqueChat`)
+export const getGroupList = () => get(`${serve}/findYjaiscrmChat`)

--- a/frontEnd/pc/src/views/groupCode/index.vue
+++ b/frontEnd/pc/src/views/groupCode/index.vue
@@ -2,7 +2,7 @@
 import * as api from './api'
 import aev from './aev.vue'
 
-let { getList, del, distributeUserCode, findIYqueUserCodeKvs, countTotalTab, countTrend } = api
+let { getList, del, distributeUserCode, findYjaiscrmUserCodeKvs, countTotalTab, countTrend } = api
 
 export default {
 	data() {
@@ -52,7 +52,7 @@ export default {
 				.finally(() => (this.$store.loading = false))
 		},
 		initSelect() {
-			findIYqueUserCodeKvs()
+			findYjaiscrmUserCodeKvs()
 				.then((data) => {
 					this.options = data.data
 					console.log(data)
@@ -165,9 +165,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>

--- a/frontEnd/pc/src/views/groupTag/api.js
+++ b/frontEnd/pc/src/views/groupTag/api.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iYqueTag'
+const serve = '/yjaiscrmTag'
 
 /**
  * 列表
@@ -8,7 +8,7 @@ const serve = '/iYqueTag'
  */
 export const getList = (data) => {
   // 添加标签分组类型(1:客户企业标签;2:客群标签)
-  return get(`${serve}/findIYqueTagGroups`, { ...data, groupTagType: 2 })
+  return get(`${serve}/findYjaiscrmTagGroups`, { ...data, groupTagType: 2 })
 }
 
 // 详情

--- a/frontEnd/pc/src/views/hotWordManage/api.ts
+++ b/frontEnd/pc/src/views/hotWordManage/api.ts
@@ -8,7 +8,7 @@ const service = '/hotWord'
 tplName,string,true,,false,模版名称
 status,string,true,,false,状态(1:启用；0:停用)
  */
-export const getList = (data) => get(`${service}/findIYqueHotWord`, data)
+export const getList = (data) => get(`${service}/findYjaiscrmHotWord`, data)
 
 /** 详情
  * @param {*} params

--- a/frontEnd/pc/src/views/hotWordManage/apiCategory.ts
+++ b/frontEnd/pc/src/views/hotWordManage/apiCategory.ts
@@ -5,7 +5,7 @@ const service = '/category'
 
 /** 列表
  */
-export const getList = (data) => get(`${service}/findIYqueCategory`, data)
+export const getList = (data) => get(`${service}/findYjaiscrmCategory`, data)
 
 /** 详情
  * @param {*} params

--- a/frontEnd/pc/src/views/hotWordManage/statistics.vue
+++ b/frontEnd/pc/src/views/hotWordManage/statistics.vue
@@ -135,9 +135,9 @@ const submitAiVisible = () => {
 <template>
   <div>
     <div class="warning">
-      <a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+      <a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
         <strong>
-          源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+          yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
         </strong>
       </a>
     </div>

--- a/frontEnd/pc/src/views/inquiryCustomer/api.js
+++ b/frontEnd/pc/src/views/inquiryCustomer/api.js
@@ -27,7 +27,7 @@ export const findAiAnalysisMsgAudits = (data) => get(`${serve}/findAiAnalysisMsg
  * @param {*} data 
  * @returns 
  */
-export const findIYqueMsgRules = (data) => get(`${serve}/findIYqueMsgRules`, data)
+export const findYjaiscrmMsgRules = (data) => get(`${serve}/findYjaiscrmMsgRules`, data)
 
 
 

--- a/frontEnd/pc/src/views/inquiryCustomer/apiLink.js
+++ b/frontEnd/pc/src/views/inquiryCustomer/apiLink.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue/shortLink'
+const serve = '/yjaiscrm/shortLink'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue/shortLink'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueShortLink`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmShortLink`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -46,11 +46,11 @@ export function update(data) {
 	return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 

--- a/frontEnd/pc/src/views/inquiryCustomer/index.vue
+++ b/frontEnd/pc/src/views/inquiryCustomer/index.vue
@@ -5,12 +5,12 @@ import { env } from '../../../sys.config'
 import aev from './aev.vue'
 import synch from './synch.vue'
 
-let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
+let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
+		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
 
 		return {
 			activeName: 'first',
@@ -73,7 +73,7 @@ export default {
 		this.getList()
 		this.getData()
 		this.findAiAnalysisMsgAudits()
-		this.findIYqueMsgRules()
+		this.findYjaiscrmMsgRules()
 	},
 	mounted() {},
 	methods: {
@@ -106,7 +106,7 @@ export default {
 					this.$store.loading = true
 					return del(ids).then((res) => {
 						this.msgSuccess('删除成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -134,7 +134,7 @@ export default {
 				.finally(() => (this.$store.loading = false))
 		},
 
-		findIYqueMsgRules(page) {
+		findYjaiscrmMsgRules(page) {
 			if(page == null){
 				page=this.aiRuleParm;
 			}
@@ -142,7 +142,7 @@ export default {
 			this.$store.loading = true
 		    console.log(page);
 			
-			findIYqueMsgRules(page)
+			findYjaiscrmMsgRules(page)
 				.then(({ data, count }) => {
 					this.aiRuleList = data
 					this.aiRuleTotal = +count
@@ -159,7 +159,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -236,7 +236,7 @@ export default {
 			}
 
 	
-			 this.findIYqueMsgRules(queryParm)
+			 this.findYjaiscrmMsgRules(queryParm)
 		},
 
 		restting() {
@@ -296,7 +296,7 @@ export default {
 						this.multipleSelection?.join?.(',')
 					).then((res) => {
 						this.msgSuccess('操作成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -309,9 +309,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>
@@ -484,7 +484,7 @@ export default {
 						:total="aiRuleTotal"
 						v-model:page="aiRuleParm.page"
 						v-model:limit="aiRuleParm.size"
-						@pagination="findIYqueMsgRules()" />
+						@pagination="findYjaiscrmMsgRules()" />
 
 						<el-dialog :title="form.id ? '编辑' : '新建'" v-model="dialogVisible" width="80%" :close-on-click-modal="false">
 							<aev v-if="dialogVisible" :data="form" ref="aev"></aev>

--- a/frontEnd/pc/src/views/inquiryKqChat/api.js
+++ b/frontEnd/pc/src/views/inquiryKqChat/api.js
@@ -27,7 +27,7 @@ export const findAiAnalysisMsgAudits = (data) => get(`${serve}/findAiAnalysisMsg
  * @param {*} data 
  * @returns 
  */
-export const findIYqueMsgRules = (data) => get(`${serve}/findIYqueMsgRules`, data)
+export const findYjaiscrmMsgRules = (data) => get(`${serve}/findYjaiscrmMsgRules`, data)
 
 
 

--- a/frontEnd/pc/src/views/inquiryKqChat/apiLink.js
+++ b/frontEnd/pc/src/views/inquiryKqChat/apiLink.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue/shortLink'
+const serve = '/yjaiscrm/shortLink'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue/shortLink'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueShortLink`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmShortLink`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -46,11 +46,11 @@ export function update(data) {
 	return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 

--- a/frontEnd/pc/src/views/inquiryKqChat/index.vue
+++ b/frontEnd/pc/src/views/inquiryKqChat/index.vue
@@ -5,12 +5,12 @@ import { env } from '../../../sys.config'
 import aev from './aev.vue'
 import synch from './synch.vue'
 
-let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
+let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
+		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
 
 		return {
 			activeName: 'first',
@@ -73,7 +73,7 @@ export default {
 		this.getList()
 		this.getData()
 		this.findAiAnalysisMsgAudits()
-		this.findIYqueMsgRules()
+		this.findYjaiscrmMsgRules()
 	},
 	mounted() {},
 	methods: {
@@ -106,7 +106,7 @@ export default {
 					this.$store.loading = true
 					return del(ids).then((res) => {
 						this.msgSuccess('删除成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -134,7 +134,7 @@ export default {
 				.finally(() => (this.$store.loading = false))
 		},
 
-		findIYqueMsgRules(page) {
+		findYjaiscrmMsgRules(page) {
 			if(page == null){
 				page=this.aiRuleParm;
 			}
@@ -142,7 +142,7 @@ export default {
 			this.$store.loading = true
 		    console.log(page);
 			
-			findIYqueMsgRules(page)
+			findYjaiscrmMsgRules(page)
 				.then(({ data, count }) => {
 					this.aiRuleList = data
 					this.aiRuleTotal = +count
@@ -159,7 +159,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -236,7 +236,7 @@ export default {
 			}
 
 	
-			 this.findIYqueMsgRules(queryParm)
+			 this.findYjaiscrmMsgRules(queryParm)
 		},
 
 		restting() {
@@ -296,7 +296,7 @@ export default {
 						this.multipleSelection?.join?.(',')
 					).then((res) => {
 						this.msgSuccess('操作成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -309,9 +309,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>
@@ -482,7 +482,7 @@ export default {
 						:total="aiRuleTotal"
 						v-model:page="aiRuleParm.page"
 						v-model:limit="aiRuleParm.size"
-						@pagination="findIYqueMsgRules()" />
+						@pagination="findYjaiscrmMsgRules()" />
 
 						<el-dialog :title="form.id ? '编辑' : '新建'" v-model="dialogVisible" width="80%" :close-on-click-modal="false">
 							<aev v-if="dialogVisible" :data="form" ref="aev"></aev>

--- a/frontEnd/pc/src/views/intentionCustomer/api.js
+++ b/frontEnd/pc/src/views/intentionCustomer/api.js
@@ -27,7 +27,7 @@ export const findAiAnalysisMsgAudits = (data) => get(`${serve}/findAiAnalysisMsg
  * @param {*} data 
  * @returns 
  */
-export const findIYqueMsgRules = (data) => get(`${serve}/findIYqueMsgRules`, data)
+export const findYjaiscrmMsgRules = (data) => get(`${serve}/findYjaiscrmMsgRules`, data)
 
 
 

--- a/frontEnd/pc/src/views/intentionCustomer/apiLink.js
+++ b/frontEnd/pc/src/views/intentionCustomer/apiLink.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue/shortLink'
+const serve = '/yjaiscrm/shortLink'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue/shortLink'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueShortLink`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmShortLink`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -46,11 +46,11 @@ export function update(data) {
 	return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 

--- a/frontEnd/pc/src/views/intentionCustomer/index.vue
+++ b/frontEnd/pc/src/views/intentionCustomer/index.vue
@@ -5,12 +5,12 @@ import { env } from '../../../sys.config'
 import aev from './aev.vue'
 import synch from './synch.vue'
 
-let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
+let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
+		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
 
 		return {
 			activeName: 'first',
@@ -73,7 +73,7 @@ export default {
 		this.getList()
 		this.getData()
 		this.findAiAnalysisMsgAudits()
-		this.findIYqueMsgRules()
+		this.findYjaiscrmMsgRules()
 	},
 	mounted() {},
 	methods: {
@@ -106,7 +106,7 @@ export default {
 					this.$store.loading = true
 					return del(ids).then((res) => {
 						this.msgSuccess('删除成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -134,7 +134,7 @@ export default {
 				.finally(() => (this.$store.loading = false))
 		},
 
-		findIYqueMsgRules(page) {
+		findYjaiscrmMsgRules(page) {
 			if(page == null){
 				page=this.aiRuleParm;
 			}
@@ -142,7 +142,7 @@ export default {
 			this.$store.loading = true
 		    console.log(page);
 			
-			findIYqueMsgRules(page)
+			findYjaiscrmMsgRules(page)
 				.then(({ data, count }) => {
 					this.aiRuleList = data
 					this.aiRuleTotal = +count
@@ -159,7 +159,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -236,7 +236,7 @@ export default {
 			}
 
 	
-			 this.findIYqueMsgRules(queryParm)
+			 this.findYjaiscrmMsgRules(queryParm)
 		},
 
 		restting() {
@@ -296,7 +296,7 @@ export default {
 						this.multipleSelection?.join?.(',')
 					).then((res) => {
 						this.msgSuccess('操作成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -309,9 +309,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>
@@ -485,7 +485,7 @@ export default {
 						:total="aiRuleTotal"
 						v-model:page="aiRuleParm.page"
 						v-model:limit="aiRuleParm.size"
-						@pagination="findIYqueMsgRules()" />
+						@pagination="findYjaiscrmMsgRules()" />
 
 						<el-dialog :title="form.id ? '编辑' : '新建'" v-model="dialogVisible" width="80%" :close-on-click-modal="false">
 							<aev v-if="dialogVisible" :data="form" ref="aev"></aev>

--- a/frontEnd/pc/src/views/intentionGroupFriend/api.js
+++ b/frontEnd/pc/src/views/intentionGroupFriend/api.js
@@ -27,7 +27,7 @@ export const findAiAnalysisMsgAudits = (data) => get(`${serve}/findAiAnalysisMsg
  * @param {*} data 
  * @returns 
  */
-export const findIYqueMsgRules = (data) => get(`${serve}/findIYqueMsgRules`, data)
+export const findYjaiscrmMsgRules = (data) => get(`${serve}/findYjaiscrmMsgRules`, data)
 
 
 

--- a/frontEnd/pc/src/views/intentionGroupFriend/apiLink.js
+++ b/frontEnd/pc/src/views/intentionGroupFriend/apiLink.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue/shortLink'
+const serve = '/yjaiscrm/shortLink'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue/shortLink'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueShortLink`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmShortLink`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -46,11 +46,11 @@ export function update(data) {
 	return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 

--- a/frontEnd/pc/src/views/intentionGroupFriend/index.vue
+++ b/frontEnd/pc/src/views/intentionGroupFriend/index.vue
@@ -5,12 +5,12 @@ import { env } from '../../../sys.config'
 import aev from './aev.vue'
 import synch from './synch.vue'
 
-let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
+let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
+		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
 
 		return {
 			activeName: 'first',
@@ -73,7 +73,7 @@ export default {
 		this.getList()
 		this.getData()
 		this.findAiAnalysisMsgAudits()
-		this.findIYqueMsgRules()
+		this.findYjaiscrmMsgRules()
 	},
 	mounted() {},
 	methods: {
@@ -106,7 +106,7 @@ export default {
 					this.$store.loading = true
 					return del(ids).then((res) => {
 						this.msgSuccess('删除成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -134,7 +134,7 @@ export default {
 				.finally(() => (this.$store.loading = false))
 		},
 
-		findIYqueMsgRules(page) {
+		findYjaiscrmMsgRules(page) {
 			if(page == null){
 				page=this.aiRuleParm;
 			}
@@ -142,7 +142,7 @@ export default {
 			this.$store.loading = true
 		    console.log(page);
 			
-			findIYqueMsgRules(page)
+			findYjaiscrmMsgRules(page)
 				.then(({ data, count }) => {
 					this.aiRuleList = data
 					this.aiRuleTotal = +count
@@ -159,7 +159,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -236,7 +236,7 @@ export default {
 			}
 
 	
-			 this.findIYqueMsgRules(queryParm)
+			 this.findYjaiscrmMsgRules(queryParm)
 		},
 
 		restting() {
@@ -296,7 +296,7 @@ export default {
 						this.multipleSelection?.join?.(',')
 					).then((res) => {
 						this.msgSuccess('操作成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -309,9 +309,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>
@@ -482,7 +482,7 @@ export default {
 						:total="aiRuleTotal"
 						v-model:page="aiRuleParm.page"
 						v-model:limit="aiRuleParm.size"
-						@pagination="findIYqueMsgRules()" />
+						@pagination="findYjaiscrmMsgRules()" />
 
 						<el-dialog :title="form.id ? '编辑' : '新建'" v-model="dialogVisible" width="80%" :close-on-click-modal="false">
 							<aev v-if="dialogVisible" :data="form" ref="aev"></aev>

--- a/frontEnd/pc/src/views/kqchat/api.js
+++ b/frontEnd/pc/src/views/kqchat/api.js
@@ -27,7 +27,7 @@ export const findAiAnalysisMsgAudits = (data) => get(`${serve}/findAiAnalysisMsg
  * @param {*} data 
  * @returns 
  */
-export const findIYqueMsgRules = (data) => get(`${serve}/findIYqueMsgRules`, data)
+export const findYjaiscrmMsgRules = (data) => get(`${serve}/findYjaiscrmMsgRules`, data)
 
 
 

--- a/frontEnd/pc/src/views/kqchat/apiLink.js
+++ b/frontEnd/pc/src/views/kqchat/apiLink.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue/shortLink'
+const serve = '/yjaiscrm/shortLink'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue/shortLink'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueShortLink`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmShortLink`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -46,11 +46,11 @@ export function update(data) {
 	return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 

--- a/frontEnd/pc/src/views/kqchat/index.vue
+++ b/frontEnd/pc/src/views/kqchat/index.vue
@@ -5,12 +5,12 @@ import { env } from '../../../sys.config'
 import aev from './aev.vue'
 import synch from './synch.vue'
 
-let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
+let { getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findIYqueMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
+		let _ = ({ getList,findAiAnalysisMsgAudits,synchMsg,buildAISessionWarning,findYjaiscrmMsgRules,del,saveOrUpdateMsgRule,batchStartOrStop} = api)
 
 		return {
 			activeName: 'first',
@@ -73,7 +73,7 @@ export default {
 		this.getList()
 		this.getData()
 		this.findAiAnalysisMsgAudits()
-		this.findIYqueMsgRules()
+		this.findYjaiscrmMsgRules()
 	},
 	mounted() {},
 	methods: {
@@ -106,7 +106,7 @@ export default {
 					this.$store.loading = true
 					return del(ids).then((res) => {
 						this.msgSuccess('删除成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -134,7 +134,7 @@ export default {
 				.finally(() => (this.$store.loading = false))
 		},
 
-		findIYqueMsgRules(page) {
+		findYjaiscrmMsgRules(page) {
 			if(page == null){
 				page=this.aiRuleParm;
 			}
@@ -142,7 +142,7 @@ export default {
 			this.$store.loading = true
 		    console.log(page);
 			
-			findIYqueMsgRules(page)
+			findYjaiscrmMsgRules(page)
 				.then(({ data, count }) => {
 					this.aiRuleList = data
 					this.aiRuleTotal = +count
@@ -159,7 +159,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -236,7 +236,7 @@ export default {
 			}
 
 	
-			 this.findIYqueMsgRules(queryParm)
+			 this.findYjaiscrmMsgRules(queryParm)
 		},
 
 		restting() {
@@ -296,7 +296,7 @@ export default {
 						this.multipleSelection?.join?.(',')
 					).then((res) => {
 						this.msgSuccess('操作成功')
-						this.findIYqueMsgRules()
+						this.findYjaiscrmMsgRules()
 					})
 				})
 				.catch((e) => {
@@ -309,9 +309,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>

--- a/frontEnd/pc/src/views/liveCode/aev.vue
+++ b/frontEnd/pc/src/views/liveCode/aev.vue
@@ -78,13 +78,13 @@ import * as apiLink from './apiLink'
 import { getUserList, getTagList, getRemarkList } from '@/api/common'
 import { dictMsgType } from '@/utils/index'
 
-let { findIYqueMsgAnnexByMsgId, findIYqueMsgPeriodAnnexByMsgId, add, update } = {}
+let { findYjaiscrmMsgAnnexByMsgId, findYjaiscrmMsgPeriodAnnexByMsgId, add, update } = {}
 
 export default {
 	props: { data: {} },
 	data() {
 		let isLink = location.href.includes('customerLink')
-		let _ = ({ findIYqueMsgAnnexByMsgId, findIYqueMsgPeriodAnnexByMsgId, add, update } = isLink ? apiLink : api)
+		let _ = ({ findYjaiscrmMsgAnnexByMsgId, findYjaiscrmMsgPeriodAnnexByMsgId, add, update } = isLink ? apiLink : api)
 		return {
 			rules: {
 				codeName: [{ required: true, message: '请输入活码名称', trigger: 'blur' }],
@@ -220,12 +220,12 @@ export default {
 
 		/** 获取详情 */
 		getDetail(id) {
-			findIYqueMsgAnnexByMsgId(id).then((res) => {
+			findYjaiscrmMsgAnnexByMsgId(id).then((res) => {
 				console.log(res.data)
 				this.form.annexLists = res.data
 			})
 			this.form.startPeriodAnnex &&
-				findIYqueMsgPeriodAnnexByMsgId(id).then((res) => {
+				findYjaiscrmMsgPeriodAnnexByMsgId(id).then((res) => {
 					console.log(res.data)
 					this.form.periodAnnexLists = res.data
 				})

--- a/frontEnd/pc/src/views/liveCode/api.js
+++ b/frontEnd/pc/src/views/liveCode/api.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue'
+const serve = '/yjaiscrm'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue'
  type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueUserCode`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmUserCode`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -48,11 +48,11 @@ export function update(data) {
     return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`/iyQue/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`/iyQue/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`/yjaiscrm/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`/yjaiscrm/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 

--- a/frontEnd/pc/src/views/liveCode/apiLink.js
+++ b/frontEnd/pc/src/views/liveCode/apiLink.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iyQue/shortLink'
+const serve = '/yjaiscrm/shortLink'
 
 /**
  * 列表
@@ -11,10 +11,10 @@ const serve = '/iyQue/shortLink'
  type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueShortLink`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmShortLink`, data)
 
 // 详情
-export const getDetail = (id) => get(`${serve}/findIYqueUserCode/${id}`)
+export const getDetail = (id) => get(`${serve}/findYjaiscrmUserCode/${id}`)
 
 // 删除
 export const del = (ids) => delt(`${serve}/${ids}`)
@@ -46,11 +46,11 @@ export function update(data) {
     return put(`${serve}/update`, data)
 }
 
-export const findIYqueMsgAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgAnnexByMsgId/${id}`)
-export const findIYqueMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findIYqueMsgPeriodAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgAnnexByMsgId/${id}`)
+export const findYjaiscrmMsgPeriodAnnexByMsgId = (id) => get(`${serve}/findYjaiscrmMsgPeriodAnnexByMsgId/${id}`)
 
 //获取所有活码id与name
-export const findIYqueUserCodeKvs = () => get(`${serve}/findIYqueUserCodeKvs`)
+export const findYjaiscrmUserCodeKvs = () => get(`${serve}/findYjaiscrmUserCodeKvs`)
 
 export const countTotalTab = (data) => get(`${serve}/countTotalTab`, data)
 
@@ -79,20 +79,20 @@ export const getShortLinkConfigIds = () => get(`${serve}/getShortLinkConfigIds`)
  * 同步员工活码（联系我配置）
  * @returns
  */
-export const synchUserCode = () => post(`/iyQue/userCode/synchUserCode`)
+export const synchUserCode = () => post(`/yjaiscrm/userCode/synchUserCode`)
 
 /**
  * 同步指定的员工活码配置
  * @param {string} configIds 配置ID列表，用逗号分隔
  * @returns
  */
-export const synchUserCodeByConfigIds = (configIds) => post(`/iyQue/userCode/synchUserCodeByConfigIds`, null, { params: { configIds } })
+export const synchUserCodeByConfigIds = (configIds) => post(`/yjaiscrm/userCode/synchUserCodeByConfigIds`, null, { params: { configIds } })
 
 /**
  * 获取所有员工活码的configId列表
  * @returns
  */
-export const getUserCodeConfigIds = () => get(`/iyQue/userCode/getUserCodeConfigIds`)
+export const getUserCodeConfigIds = () => get(`/yjaiscrm/userCode/getUserCodeConfigIds`)
 
 /**
  * 获取获客链接的客户列表

--- a/frontEnd/pc/src/views/liveCode/index.vue
+++ b/frontEnd/pc/src/views/liveCode/index.vue
@@ -9,7 +9,7 @@ let {
   getList,
   del,
   distributeUserCode,
-  findIYqueUserCodeKvs,
+  findYjaiscrmUserCodeKvs,
   countTotalTab,
   countTrend,
   synchShortLink,
@@ -28,7 +28,7 @@ export default {
       getList,
       del,
       distributeUserCode,
-      findIYqueUserCodeKvs,
+      findYjaiscrmUserCodeKvs,
       countTotalTab,
       countTrend,
       synchShortLink,
@@ -162,7 +162,7 @@ export default {
         .finally(() => (this.$store.loading = false))
     },
     initSelect() {
-      findIYqueUserCodeKvs()
+      findYjaiscrmUserCodeKvs()
         .then((data) => {
           this.options = data.data
           console.log(data)
@@ -589,9 +589,9 @@ export default {
 <template>
   <div>
     <div class="warning">
-      <a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+      <a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
         <strong>
-          源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+          yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
         </strong>
       </a>
     </div>

--- a/frontEnd/pc/src/views/massMarketing/api.ts
+++ b/frontEnd/pc/src/views/massMarketing/api.ts
@@ -8,12 +8,12 @@ const service = '/groupMsg'
 tplName,string,true,,false,模版名称
 status,string,true,,false,状态(1:启用；0:停用)
  */
-export const getList = (data) => get(`${service}/findIYqueGroupMsgPage`, data)
+export const getList = (data) => get(`${service}/findYjaiscrmGroupMsgPage`, data)
 
 /** 详情
  * @param {*} params
  */
-export const getDetail = (id) => get(`${service}/findIYqueGroupMsgById/${id}`)
+export const getDetail = (id) => get(`${service}/findYjaiscrmGroupMsgById/${id}`)
 
 /** 删除
  * @param {*} ids

--- a/frontEnd/pc/src/views/riskControl/violationIntercept/api.js
+++ b/frontEnd/pc/src/views/riskControl/violationIntercept/api.js
@@ -5,7 +5,7 @@ import request from '@/utils/request'
  */
 export const getList = (params) => {
   return request({
-    url: '/iYqueSessionInterceptRule/findAll',
+    url: '/yjaiscrmSessionInterceptRule/findAll',
     method: 'get',
     params,
   })
@@ -16,7 +16,7 @@ export const getList = (params) => {
  */
 export const saveOrUpdate = (data) => {
   return request({
-    url: '/iYqueSessionInterceptRule/saveOrUpdate',
+    url: '/yjaiscrmSessionInterceptRule/saveOrUpdate',
     method: 'post',
     data,
   })
@@ -27,7 +27,7 @@ export const saveOrUpdate = (data) => {
  */
 export const del = (id) => {
   return request({
-    url: `/iYqueSessionInterceptRule/${id}`,
+    url: `/yjaiscrmSessionInterceptRule/${id}`,
     method: 'delete',
   })
 }
@@ -37,7 +37,7 @@ export const del = (id) => {
  */
 export const batchDelete = (ids) => {
   return request({
-    url: `/iYqueSessionInterceptRule/batchDelete/${ids}`,
+    url: `/yjaiscrmSessionInterceptRule/batchDelete/${ids}`,
     method: 'delete',
   })
 }
@@ -47,7 +47,7 @@ export const batchDelete = (ids) => {
  */
 export const getById = (id) => {
   return request({
-    url: `/iYqueSessionInterceptRule/${id}`,
+    url: `/yjaiscrmSessionInterceptRule/${id}`,
     method: 'get',
   })
 }
@@ -57,7 +57,7 @@ export const getById = (id) => {
  */
 export const getStaffList = () => {
   return request({
-    url: '/iYqueUser/findIYqueUser',
+    url: '/yjaiscrmUser/findYjaiscrmUser',
     method: 'get'
   }).then((res) => {
     if (res.code == 200) {

--- a/frontEnd/pc/src/views/riskControl/violationIntercept/index.vue
+++ b/frontEnd/pc/src/views/riskControl/violationIntercept/index.vue
@@ -310,8 +310,8 @@ export default {
     color: #666;
   }
   
-  // 源雀SCRM广告横幅样式
-  .iyque-ad-banner {
+  // yjaiscrm SCRM广告横幅样式
+  .yjaiscrm-ad-banner {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
     padding: 12px 0;

--- a/frontEnd/pc/src/views/screenShot/index.vue
+++ b/frontEnd/pc/src/views/screenShot/index.vue
@@ -102,7 +102,7 @@ export default {
 				.submit()
 				.then(() => {
 					this.dialogVisible = false
-					return this.findIYqueMsgRules()
+					return this.findYjaiscrmMsgRules()
 				})
 				.catch((e) => console.error(e))
 				.finally(() => (this.loading = false))
@@ -155,9 +155,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>

--- a/frontEnd/pc/src/views/system/login/api.js
+++ b/frontEnd/pc/src/views/system/login/api.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, del: _del } = request
-const serve = '/iYqueSys'
+const serve = '/yjaiscrmSys'
 
 export const login = (data) => post(`${serve}/login`, data)
 /**

--- a/frontEnd/pc/src/views/system/login/index.vue
+++ b/frontEnd/pc/src/views/system/login/index.vue
@@ -16,17 +16,17 @@
           <!-- <span v-html="sysConfig.SYSTEM_SLOGAN"></span> -->
         </div>
         <div class="leading-[40px]">
-          源雀SCRM是基于源码100%开放策略的企业微信SCRM，从源头解决了企业私域建设核心痛点，实现高自由度、高私有化及高安全性。系统具备四大优势：
+          yjaiscrm SCRM是基于源码100%开放策略的企业微信SCRM，从源头解决了企业私域建设核心痛点，实现高自由度、高私有化及高安全性。系统具备四大优势：
           <ul>
             <li class="!list-disc !list-inside !pl-[30px]">系统高度可用，部署灵活高效</li>
             <li class="!list-disc !list-inside !pl-[30px]">研发降本增效，满足定制需求</li>
             <li class="!list-disc !list-inside !pl-[30px]">数据安全可控，自主知识产权</li>
             <li class="!list-disc !list-inside !pl-[30px]">降低云服务依赖与供应商绑定</li>
           </ul>
-          同时源雀积极拥抱开源，同步推出完全开源、免费使用AI开源版，结合DeepSeek等AI大模型，让企业快速拥有更强大、更丰富、更智能的企业微信管理能力。
+          同时yjaiscrm积极拥抱开源，同步推出完全开源、免费使用AI开源版，结合DeepSeek等AI大模型，让企业快速拥有更强大、更丰富、更智能的企业微信管理能力。
         </div>
         <div class="--Color bold font16 mt20">
-          <a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">立即了解源雀SCRM →</a>
+          <a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">立即了解yjaiscrm SCRM →</a>
         </div>
       </div>
       <div class="w-[50%] bg-(--BgWhite) relative">

--- a/frontEnd/pc/src/views/user/api.js
+++ b/frontEnd/pc/src/views/user/api.js
@@ -1,6 +1,6 @@
 import request from '@/utils/request'
 const { get, post, put, delt } = request
-const serve = '/iYqueUser'
+const serve = '/yjaiscrmUser'
 
 /**
  * 列表
@@ -11,7 +11,7 @@ const serve = '/iYqueUser'
   type:''
  }
  */
-export const getList = (data) => get(`${serve}/findIYqueUserPage`, data)
+export const getList = (data) => get(`${serve}/findYjaiscrmUserPage`, data)
 
 
 
@@ -19,5 +19,5 @@ export const getList = (data) => get(`${serve}/findIYqueUserPage`, data)
  * 成员同步
  * @returns 
  */
-export const synchIyqueUser = () => post(`${serve}/synchIyqueUser`)
+export const synchYjaiscrmUser = () => post(`${serve}/synchYjaiscrmUser`)
 

--- a/frontEnd/pc/src/views/user/index.vue
+++ b/frontEnd/pc/src/views/user/index.vue
@@ -1,12 +1,12 @@
 <script>
 import * as api from './api'
 import { env } from '../../../sys.config'
-let { getList,synchIyqueUser} = {}
+let { getList,synchYjaiscrmUser} = {}
 
 export default {
 	data() {
 		// let isLink = location.href.includes('customerLink')
-		let _ = ({ getList,synchIyqueUser} = api)
+		let _ = ({ getList,synchYjaiscrmUser} = api)
 
 		return {
 			activeName: 'first',
@@ -67,7 +67,7 @@ export default {
 
 
 		synchUser() {
-            synchIyqueUser()
+            synchYjaiscrmUser()
 			 .then(response => {
 			
 				this.msgSuccess(response.msg)
@@ -109,9 +109,9 @@ export default {
 <template>
 	<div>
 		<div class="warning">
-			<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">
+			<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">
 				<strong>
-					源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.iyque.cn/
+					yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台。:https://www.yjaiscrm.cn/
 				</strong>
 			</a>
 		</div>

--- a/frontEnd/pc/sys.config.ts
+++ b/frontEnd/pc/sys.config.ts
@@ -6,14 +6,14 @@ const envs = {
     BASE_API: 'http://127.0.0.1:8085',
   },
   test: {
-    DOMAIN: 'https://show.iyque.cn',
+    DOMAIN: 'https://show.yjaiscrm.cn',
     BASE_URL: '/tools/',
-    BASE_API: 'https://show.iyque.cn/iyque',
+    BASE_API: 'https://show.yjaiscrm.cn/yjaiscrm',
   },
   production: {
-    DOMAIN: 'https://iyque.cn',
+    DOMAIN: 'https://yjaiscrm.cn',
     BASE_URL: '/tools/',
-    BASE_API: 'https://iyque.cn/iyque',
+    BASE_API: 'https://yjaiscrm.cn/yjaiscrm',
   },
 }
 
@@ -26,9 +26,9 @@ export const env = { ...envs[mode], ENV: mode }
 
 // 系统常量配置
 export const common = {
-  SYSTEM_NAME: '源雀', // 系统简称
+  SYSTEM_NAME: 'yjaiscrm', // 系统简称
   SYSTEM_SLOGAN:
-    '<a href="https://www.iyque.cn?utm_source=iyquecode" target="_blank">源雀Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台.</a> ', // 系统标语
-  COPYRIGHT: 'Copyright © 2022-2025 源雀 All Rights Reserved.', // 版权信息
+    '<a href="https://www.yjaiscrm.cn?utm_source=yjaiscrmcode" target="_blank">yjaiscrm Scrm-是基于Java源码交付的企微SCRM,帮助企业构建高度自由安全的私域平台.</a> ', // 系统标语
+  COPYRIGHT: 'Copyright © 2022-2025 yjaiscrm All Rights Reserved.', // 版权信息
   LOGO: env.BASE_URL + 'static/logo.png', // 深色logo
 }


### PR DESCRIPTION
## Summary
- Rename brand identifier `iyque` -> `yjaiscrm` (and 中文 `源雀` -> `yjaiscrm`) across the **PC management console** (`frontEnd/pc/`), Unit 2 of the monorepo-wide rename.
- 55 files modified, 240 insertions / 240 deletions — pure substitution, no logic change.
- API URL prefixes (`/iYqueSys`, `/iYqueAi/*`, `/iyQue/shortLink`, `/iYqueComplaint`, …), function/path identifiers (`findIYque*`, `synchIyque*`, `setIYQueComplaintTip`, …), `sys.config.ts` (test/prod DOMAIN/BASE_API + SYSTEM_NAME/SLOGAN/COPYRIGHT), `index.html` `<title>`, brand banners across views, sidebar promo link, the welcome-message default in `WelcomeForm.vue`, and the `.iyque-ad-banner` CSS class are all renamed per the agreed deterministic rule.

## Casing rule
Case-insensitive matches of `iyque` (`iyque`/`IYque`/`IYQue`/`IyQue`/`iYque`/`iyQue`/`IYQUE`) collapse to `Yjaiscrm` when the matched substring starts with capital `I`, else to `yjaiscrm`. Chinese brand text `源雀` / `源雀SCRM` / `源雀Scrm` / `源雀scrm` becomes `yjaiscrm` with any `SCRM`/`Scrm`/`scrm` suffix preserved (separated by a space).

This matches the rule used by Unit 1 (backend `@RequestMapping`), Unit 3 (mobile), and Unit 4 (nginx + root docs) so PC <-> backend URLs stay aligned.

## Test plan
- [x] `grep -ri "iyque" frontEnd/pc --exclude-dir=node_modules --exclude-dir=dist` returns 0 lines.
- [x] `grep -r "源雀" frontEnd/pc --exclude-dir=node_modules --exclude-dir=dist` returns 0 lines.
- [x] `cd frontEnd/pc && npm install && npm run build` succeeds.
- [x] `npm run type-check` reports the same 160 pre-existing errors as `master` (sys.config.ts, vite.config.ts, contentCenter/combinedRhetoric/aev.vue) — no new errors introduced by this rename.
- [ ] End-to-end smoke (post-merge): start backend on `:8085` (with Unit 1 merged so /yjaiscrmSys etc. exist), `npm run dev`, log in via `/yjaiscrmSys/login`, verify menus/customer/group/AI/login pages render and call the new endpoints with 200s.

## Notes
- `package.json`'s `name` field was already `yq` (no `iyque`), per the team-lead spec — left untouched.
- The default welcome message in `WelcomeForm.vue` line 18 reads `欢迎使用yjaiscrm scrm👉http://yjaiscrm.cn` after the literal spec transform (`源雀scrm` -> `yjaiscrm scrm`). This is the spec-mandated text; if the rebrand later prefers a non-redundant phrasing, it can be tweaked in a follow-up content-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)